### PR TITLE
Redownload volumes

### DIFF
--- a/iblatlas/__init__.py
+++ b/iblatlas/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 """A package for working with brain atlases.
 

--- a/iblatlas/atlas.py
+++ b/iblatlas/atlas.py
@@ -4,7 +4,7 @@ Classes for manipulating brain atlases, insertions, and coordinates.
 from pathlib import Path, PurePosixPath
 from dataclasses import dataclass
 import logging
-import shutil
+import os
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -1463,8 +1463,7 @@ class AllenAtlas(BrainAtlas):
             except nrrd.NRRDError as e:
                 _logger.warning(f"An error occured when loading atlas volumes: {e}. \
                                   Deleting and redownloading the files.")
-                cache_dir = AllenAtlas._get_cache_dir()
-                shutil.rmtree(cache_dir / "Histology/ATLAS/Needles/Allen")
+                os.remove(file_volume)
                 file_volume = _download_atlas_allen(file_volume)
                 volume, _ = nrrd.read(file_volume, index_order='C')  # ml, dv, ap
             # we want the coronal slice to be the most contiguous

--- a/iblatlas/atlas.py
+++ b/iblatlas/atlas.py
@@ -4,7 +4,6 @@ Classes for manipulating brain atlases, insertions, and coordinates.
 from pathlib import Path, PurePosixPath
 from dataclasses import dataclass
 import logging
-import os
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -1456,14 +1455,14 @@ class AllenAtlas(BrainAtlas):
         super().__init__(image, label, dxyz, regions, ibregma, dims2xyz=dims2xyz, xyz2dims=xyz2dims)
 
     @staticmethod
-    def _read_volume(file_volume):
+    def _read_volume(file_volume: Path):
         if file_volume.suffix == '.nrrd':
             try:
                 volume, _ = nrrd.read(file_volume, index_order='C')  # ml, dv, ap
             except nrrd.NRRDError as e:
-                _logger.warning(f"An error occured when loading atlas volumes: {e}. \
-                                  Deleting and redownloading the files.")
-                os.remove(file_volume)
+                _logger.error(f"An error occured when loading atlas volumes: {e}. \
+                                Deleting and redownloading the files.")
+                file_volume.unlink(missing_ok=True)
                 file_volume = _download_atlas_allen(file_volume)
                 volume, _ = nrrd.read(file_volume, index_order='C')  # ml, dv, ap
             # we want the coronal slice to be the most contiguous


### PR DESCRIPTION
tested by locally corrputing atlas file with
```
echo -n -e '\xFF' | dd of=average_template_25.nrrd bs=1 count=1 conv=notrunc
```
