### PR TITLE
Add merfish.load_volume() to load and denoise MERFISH cell-type density volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.0]
+### Added
+- `iblatlas.genomics.merfish.load_volume` to load MERFISH cell-type density volumes, denoised by default
+
 ## [1.0.0]
 ### Added
 - `CITATION.cff` citation file for the repository

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ of more complex visualization tools such as `pyqt`.**
 [Notebooks and examples](https://int-brain-lab.github.io/iblenv/notebooks_external/atlas_working_with_ibllib_atlas.html)
 
 ## Installation
-`pip install iblatlas`
+`uv pip install iblatlas`
 
 For GUI features, you'll need to install with optional dependencies:
-`pip install iblatlas[gui]`
+`uv pip install iblatlas[gui]`
 
 ## Contributing
 Changes are merged by pull requests.

--- a/iblatlas/__init__.py
+++ b/iblatlas/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 """A package for working with brain atlases.
 

--- a/iblatlas/genomics/agea.py
+++ b/iblatlas/genomics/agea.py
@@ -15,6 +15,34 @@ _logger = logging.getLogger(__name__)
 _, NML, NDV, NAP = DIM_EXP = (4345, 58, 41, 67)  # nexperiments, nml, ndv, nap
 
 
+def load_atlas(folder_cache=None):
+    """
+    Builds the brain atlas matching the AGEA / MERFISH 200 um grid.
+
+    Only fetches `image.npy` and `label.npy` (a few MB) rather than the full `atlas/agea` S3
+    folder, so this is cheap to call even when the gene expression volumes themselves are not
+    needed -- e.g. to index a MERFISH volume (`iblatlas.genomics.merfish.load_volume`).
+
+    :param folder_cache:
+    :return: a brainatlas object with the labels and coordinates matching the gene expression /
+     MERFISH volumes
+    """
+    folder_cache = Path(folder_cache or atlas.AllenAtlas._get_cache_dir().joinpath('agea'))
+    for filename in ('image.npy', 'label.npy'):
+        file_path = folder_cache.joinpath(filename)
+        if not file_path.exists():
+            aws.s3_download_file(f'atlas/agea/{filename}', file_path)
+    return atlas.BrainAtlas(
+        image=np.load(folder_cache.joinpath('image.npy')),
+        label=np.load(folder_cache.joinpath('label.npy')),
+        dxyz=200 / 1e6 * np.array([1, -1, -1]),
+        regions=atlas.BrainRegions(),
+        iorigin=atlas.ALLEN_CCF_LANDMARKS_MLAPDV_UM['bregma'] / 200 + np.array([0, 0, 0]),
+        dims2xyz=[0, 2, 1],
+        xyz2dims=[0, 2, 1]
+    )
+
+
 def load(folder_cache=None, expression_size=DIM_EXP, label=''):
     """
     Reads in the Allen gene expression experiments binary data.
@@ -39,21 +67,11 @@ def load(folder_cache=None, expression_size=DIM_EXP, label=''):
         aws.s3_download_folder('atlas/agea', folder_cache)
 
     # load the genes dataframe and the gene expression volumes
-    file_parquet = Path(folder_cache).joinpath('gene-expression.pqt')
+    file_parquet = folder_cache.joinpath('gene-expression.pqt')
     fn = f'gene-expression-{label}.bin' if label else 'gene-expression.bin'
-    file_expression = Path(folder_cache).joinpath(fn)
+    file_expression = folder_cache.joinpath(fn)
     df_genes = pd.read_parquet(file_parquet)
     expression_volumes = np.memmap(file_expression, dtype=np.float16, mode='r', offset=0, shape=expression_size)
-
-    # create a brain atlas object with the gene expression volume geometry and pre-computed labels
-    atlas_agea = atlas.BrainAtlas(
-        image=np.load(Path(folder_cache).joinpath('image.npy')),
-        label=np.load(Path(folder_cache).joinpath('label.npy')),
-        dxyz=200 / 1e6 * np.array([1, -1, -1]),
-        regions=atlas.BrainRegions(),
-        iorigin=atlas.ALLEN_CCF_LANDMARKS_MLAPDV_UM['bregma'] / 200 + np.array([0, 0, 0]),
-        dims2xyz=[0, 2, 1],
-        xyz2dims=[0, 2, 1]
-    )
+    atlas_agea = load_atlas(folder_cache)
 
     return df_genes, expression_volumes, atlas_agea

--- a/iblatlas/genomics/merfish.py
+++ b/iblatlas/genomics/merfish.py
@@ -3,10 +3,12 @@ from pathlib import Path
 
 import pandas as pd
 import numpy as np
+from scipy.ndimage import gaussian_filter
 
 import one.remote.aws as aws
 
 from iblatlas import atlas
+from iblatlas.genomics import agea
 
 _logger = logging.getLogger(__name__)
 
@@ -48,6 +50,85 @@ def load(folder_cache=None):
     df_genes = pd.read_parquet(folder_cache.joinpath('genes.pqt'))
     df_neurotransmitters = pd.read_parquet(folder_cache.joinpath('neurotransmitters.pqt'))
     return df_cells, df_classes, df_subclasses, df_supertypes, df_clusters, df_genes, df_neurotransmitters
+
+
+def denoise_volume(volume, brain_mask, n_drop_non_neuronal=5, sigma=0.5, seed=42):
+    """
+    Denoise a raw MERFISH cell-type density volume.
+
+    Raw volumes can contain NaN voxels with no nearby source data. Naively filling *every* NaN
+    voxel with Dirichlet noise also fills the background outside the brain with random noise,
+    which then bleeds a few voxels inward once Gaussian-smoothed. This restricts the
+    fill/smooth/normalize steps to `brain_mask` and re-zeroes anything outside it after smoothing.
+
+    :param volume: (n_types, dim0, dim1, dim2) raw density volume, as returned by
+     `load_volume(..., label='')`
+    :param brain_mask: (dim0, dim1, dim2) bool, True for voxels inside the brain (e.g.
+     `atlas_agea.label != 0`)
+    :param n_drop_non_neuronal: number of trailing non-neuronal types to drop (Astro-Epen,
+     OPC-Oligo, OEC, Vascular, Immune are always the last 5 rows at the 'class' level); set to 0
+     to keep all types
+    :param sigma: Gaussian smoothing sigma in voxels, applied per type independently; set to 0 to
+     disable
+    :param seed: seed for the Dirichlet noise used to fill in-brain voxels that are NaN across
+     every type
+    :return: a (n_types - n_drop_non_neuronal, dim0, dim1, dim2) float32 array; in-brain voxels
+     sum to ~1 over the type axis, out-of-brain voxels are 0
+    """
+    rng = np.random.RandomState(seed)
+    vol = np.array(volume[: len(volume) - n_drop_non_neuronal], dtype=np.float32)
+    all_nan = np.isnan(vol).all(axis=0) & brain_mask
+    vol = np.nan_to_num(vol, nan=0.0)
+    vol[:, all_nan] = rng.dirichlet(np.ones(vol.shape[0]), size=all_nan.sum()).T
+    if sigma:
+        vol = np.stack([gaussian_filter(channel, sigma=sigma) for channel in vol])
+    vol *= brain_mask  # undo any smoothing bleed into the background
+    vol /= vol.sum(axis=0, keepdims=True) + 1e-10
+    return vol
+
+
+def load_volume(level='class', label='processed', folder_cache=None):
+    """
+    Reads in a pre-computed MERFISH cell-type density volume and its type labels.
+
+    These are dense 4-D arrays (one 3-D volume per cell type), built by
+    `iblatlas/genomics/merfish_scrapping/02_create_volumes.py` on the same 200 um grid as
+    `iblatlas.genomics.agea.load()` (not the default 25 um `AllenAtlas()` grid).
+
+    :param level: taxonomy level to load, one of 'class', 'subclass', 'supertype', 'cluster'
+    :param label: which volume to return
+     - '': the raw, unprocessed volume (may contain NaN; returned memory-mapped)
+     - 'processed': denoised via `denoise_volume()` (non-neuronal types dropped, NaNs filled,
+       Gaussian-smoothed, renormalized to sum to 1 per in-brain voxel). Default -- unlike
+       `agea.load()`, which defaults to the raw (`label=''`) volume.
+    :param folder_cache:
+    :return:
+    volume: a (n_types, ml, dv, ap) array, one density volume per cell type, on the same grid as
+     the `expression_volumes` returned by `agea.load()`. float16 memory-mapped if label='', float32
+     in memory if label='processed'.
+    labels: a (n_types,) array of type ids for each channel of `volume`, matching the index of the
+     corresponding dataframe returned by `load()` (e.g. df_classes.index for level='class').
+     Truncated to match `volume` when label='processed' drops non-neuronal types.
+    atlas_agea: a brainatlas object with the labels and coordinates matching `volume` (same object
+     as returned by `agea.load()` / `agea.load_atlas()`)
+    """
+    feasible_levels = ['class', 'subclass', 'supertype', 'cluster']
+    assert level in feasible_levels, f'level must be one of {feasible_levels}'
+    assert label in ('', 'processed'), "label must be '' (raw) or 'processed'"
+    folder_cache = Path(folder_cache or atlas.AllenAtlas._get_cache_dir().joinpath('merfish'))
+    # download only the 2 files needed for this level, not the whole `atlas/merfish` folder
+    # (which also holds the multi-GB cell tables and the volumes for every other level)
+    for filename in (f'merfish_{level}.npy', f'merfish_{level}_labels.npy'):
+        file_path = folder_cache.joinpath(filename)
+        if not file_path.exists():
+            aws.s3_download_file(f'atlas/merfish/{filename}', file_path)
+    volume = np.load(folder_cache.joinpath(f'merfish_{level}.npy'), mmap_mode='r')
+    labels = np.load(folder_cache.joinpath(f'merfish_{level}_labels.npy'), allow_pickle=True)
+    atlas_agea = agea.load_atlas()
+    if label == 'processed':
+        volume = denoise_volume(volume, atlas_agea.label != 0)
+        labels = labels[:volume.shape[0]]
+    return volume, labels, atlas_agea
 
 
 def int2rgb(array, dtype=None):

--- a/iblatlas/tests/test_genomics.py
+++ b/iblatlas/tests/test_genomics.py
@@ -105,6 +105,8 @@ class TestMerfishLoadVolume(unittest.TestCase):
                 np.testing.assert_array_equal(np.asarray(vol_raw), volume)
                 np.testing.assert_array_equal(lab_raw, labels)
                 self.assertIs(ba, fake_atlas)
+                # on windows we need to close the memmap for the tempdir to be deleted
+                vol_raw._mmap.close()
 
                 vol_proc, lab_proc, _ = merfish.load_volume(
                     level='class', label='processed', folder_cache=folder_cache)

--- a/iblatlas/tests/test_genomics.py
+++ b/iblatlas/tests/test_genomics.py
@@ -40,6 +40,15 @@ class TestLoadAgea(unittest.TestCase):
             # on windows we need to close the memmap for the tempdir to be deleted
             gene_expression_volumes._mmap.close()
 
+    def test_load_atlas(self):
+        """`load_atlas()` should build the same atlas as `load()`, from just image.npy/label.npy."""
+        with tempfile.TemporaryDirectory() as folder_cache:
+            np.save(Path(folder_cache).joinpath('image.npy'), np.random.rand(*agea.DIM_EXP[1:]))
+            np.save(Path(folder_cache).joinpath('label.npy'), np.random.rand(*agea.DIM_EXP[1:]))
+            atlas_agea = agea.load_atlas(folder_cache=folder_cache)
+            self.assertEqual(atlas_agea.image.shape, (58, 41, 67))
+            self.assertEqual(atlas_agea.label.shape, (58, 41, 67))
+
 
 class TestMerfish(unittest.TestCase):
 
@@ -49,3 +58,61 @@ class TestMerfish(unittest.TestCase):
             merfish.int2rgb(array), np.array([[1., 0.4, 0., 1.], [0.56470588, 0.87843137, 0.9372549, 1.]])))
         assert np.all(np.isclose(
             merfish.int2rgb(array, dtype=int), np.array([[255, 102, 0, 255], [144, 224, 239, 255]], dtype=int)))
+
+
+class TestMerfishDenoiseVolume(unittest.TestCase):
+
+    def test_denoise_volume(self):
+        """NaN-fill is restricted to in-brain voxels, and in-brain voxels sum to 1 afterwards."""
+        n_types, shape = 5, (4, 4, 4)
+        rng = np.random.RandomState(0)
+        volume = rng.rand(n_types, *shape).astype(np.float32)
+        brain_mask = np.ones(shape, dtype=bool)
+        brain_mask[0, 0, 0] = False  # a background voxel, outside the brain
+        volume[:, 1, 1, 1] = np.nan  # a voxel with no data at all, inside the brain
+
+        denoised = merfish.denoise_volume(volume, brain_mask, n_drop_non_neuronal=2, sigma=0, seed=1)
+
+        self.assertEqual(denoised.shape, (n_types - 2, *shape))
+        np.testing.assert_allclose(denoised.sum(axis=0)[brain_mask], 1.0, atol=1e-5)
+        np.testing.assert_array_equal(denoised[:, 0, 0, 0], 0.0)  # out-of-brain stays at 0
+        self.assertTrue(np.all(denoised[:, 1, 1, 1] >= 0))  # NaN got a valid Dirichlet fill
+        self.assertAlmostEqual(float(denoised[:, 1, 1, 1].sum()), 1.0, places=5)
+
+    def test_denoise_volume_no_smoothing_no_drop(self):
+        """With sigma=0, n_drop_non_neuronal=0 and no NaNs, this is just a per-voxel renormalize."""
+        n_types, shape = 3, (2, 2, 2)
+        volume = np.ones((n_types, *shape), dtype=np.float32)
+        brain_mask = np.ones(shape, dtype=bool)
+        denoised = merfish.denoise_volume(volume, brain_mask, n_drop_non_neuronal=0, sigma=0)
+        self.assertEqual(denoised.shape, (n_types, *shape))
+        np.testing.assert_allclose(denoised, 1.0 / n_types, atol=1e-6)
+
+
+class TestMerfishLoadVolume(unittest.TestCase):
+
+    def test_load_volume(self):
+        with tempfile.TemporaryDirectory() as folder_cache:
+            n_types, shape = 8, (4, 5, 6)
+            volume = np.random.RandomState(2).rand(n_types, *shape).astype(np.float16)
+            labels = np.arange(1, n_types + 1)
+            np.save(Path(folder_cache, 'merfish_class.npy'), volume)
+            np.save(Path(folder_cache, 'merfish_class_labels.npy'), labels)
+            fake_atlas = unittest.mock.MagicMock(label=np.ones(shape))
+
+            with unittest.mock.patch('iblatlas.genomics.agea.load_atlas', return_value=fake_atlas):
+                vol_raw, lab_raw, ba = merfish.load_volume(level='class', label='', folder_cache=folder_cache)
+                np.testing.assert_array_equal(np.asarray(vol_raw), volume)
+                np.testing.assert_array_equal(lab_raw, labels)
+                self.assertIs(ba, fake_atlas)
+
+                vol_proc, lab_proc, _ = merfish.load_volume(
+                    level='class', label='processed', folder_cache=folder_cache)
+                self.assertEqual(vol_proc.shape, (n_types - 5, *shape))  # default n_drop_non_neuronal=5
+                np.testing.assert_array_equal(lab_proc, labels[:n_types - 5])
+
+    def test_load_volume_bad_args(self):
+        with self.assertRaises(AssertionError):
+            merfish.load_volume(level='not_a_level')
+        with self.assertRaises(AssertionError):
+            merfish.load_volume(label='not_a_label')


### PR DESCRIPTION
## Summary
- `merfish.load_volume(level, label='processed')` loads a MERFISH cell-type density volume (raw or denoised), downloading only the files needed for that level instead of the whole `atlas/merfish` S3 folder.
- `merfish.denoise_volume()` fills NaNs, smooths and renormalizes a raw volume, restricted to in-brain voxels (avoids polluting the background with Dirichlet noise that then bleeds into the brain surface when smoothed).
- `agea.load_atlas()` builds the AGEA/MERFISH atlas from just `image.npy`/`label.npy`, without downloading the full gene-expression volumes.
- Version bump to 1.1.0.

## Test plan
- [x] `python -m unittest discover` in `iblatlas/tests` (7/7 pass, including new tests for the above)
- [x] `python -m flake8`